### PR TITLE
change the hideTitle prop to hideEmptyList

### DIFF
--- a/components/Dashboard/TaskTab.tsx
+++ b/components/Dashboard/TaskTab.tsx
@@ -54,7 +54,7 @@ const TaskTab: React.FunctionComponent<Props> = ({
         statusList={TASK_TYPES}
         showInitiativeName={showInitiativeName}
         showProductName={showProductName}
-        hideTitle={true}
+        hideEmptyList={true}
       />
       <FilterModal
         modal={filterModal}


### PR DESCRIPTION
The hideTitle prop is not existent on the TaskTableTiles component. 

i exchanged hideTitle with hideEmptyList prop which is existent on the component. 

please refer to the screenshots  attached. 
![image](https://user-images.githubusercontent.com/48476293/149520541-b40362dc-70ff-4ce4-a1ad-b8f9cf407864.png)
![image](https://user-images.githubusercontent.com/48476293/149520548-fe2ff8dd-c4e3-4cfd-8f7d-9ee4e08191d6.png)
 