### PR TITLE
Provide additional options to choose when rejecting a contribution

### DIFF
--- a/components/Products/CustomModal/index.tsx
+++ b/components/Products/CustomModal/index.tsx
@@ -8,6 +8,8 @@ type Props = {
     title: string;
     message?: string;
     submitText?: string;
+    secondarySubmits?: [text: string, action: Function]
+    displayCancelButton?: boolean
 };
 
 const CustomModal: React.SFC<Props> = ({
@@ -17,6 +19,8 @@ const CustomModal: React.SFC<Props> = ({
   title,
   message  = "Are you sure?",
   submitText = "Submit",
+  secondarySubmits = [],
+  displayCancelButton = true
 }) => {  
   const handleCancel = () => {
     closeModal(!modal);
@@ -26,6 +30,15 @@ const CustomModal: React.SFC<Props> = ({
     submit();
   }
 
+  const cancelButton = <Button key="back" onClick={handleCancel}>Cancel</Button>
+
+  const secondarySubmitsButtons = secondarySubmits.map((secondarySubmit, index) =>
+    <Button key={`secondary-submit${index}`} onClick={secondarySubmit.action}>
+      {secondarySubmit.text}
+    </Button>)
+
+    const primarySubmitButton = <Button key="submit" type="primary" onClick={handleOk}>{submitText}</Button>
+
   return (
     <>
       <Modal
@@ -33,12 +46,9 @@ const CustomModal: React.SFC<Props> = ({
         visible={modal}
         onCancel={handleCancel}
         footer={[
-          <Button key="back" onClick={handleCancel}>
-            Cancel
-          </Button>,
-          <Button key="submit" type="primary" onClick={handleOk}>
-            {submitText}
-          </Button>,
+          displayCancelButton && cancelButton,
+          ...secondarySubmitsButtons,
+          primarySubmitButton
         ]}
         maskClosable={false}
       >

--- a/components/Products/DeliveryMessageModal/index.tsx
+++ b/components/Products/DeliveryMessageModal/index.tsx
@@ -10,8 +10,9 @@ import {getProp} from "../../../utilities/filters";
 type Props = {
     modal: boolean,
     closeModal: Function,
-    submit: Function,
     reject: Function,
+    requestRevision: Function,
+    submit: Function,
     taskId: number
 };
 
@@ -41,8 +42,9 @@ type Attachment = {
 const DeliveryMessageModal: React.SFC<Props> = ({
                                                     modal,
                                                     closeModal,
-                                                    submit,
                                                     reject,
+                                                    requestRevision,
+                                                    submit,
                                                     taskId
                                                 }) => {
     const [attempt, setAttempt] = useState<TaskDeliveryAttempt>({
@@ -73,13 +75,19 @@ const DeliveryMessageModal: React.SFC<Props> = ({
         closeModal(!modal);
     };
 
+    const handleReject = () => {
+        reject();
+    }
+
+    const handleRequestRevision = () => {
+        requestRevision();
+    }
+
     const handleOk = () => {
         submit();
     }
 
-    const handleReject = () => {
-        reject();
-    }
+
 
     console.log(attempt)
 
@@ -91,8 +99,12 @@ const DeliveryMessageModal: React.SFC<Props> = ({
                 onCancel={handleCancel}
                 footer={[
                     <Button style={{borderRadius: 4, borderWidth: 0, marginRight: 8}} key="back"
-                            onClick={handleReject} type="primary">
-                        Reject the work
+                            onClick={handleReject}>
+                        Unassign
+                    </Button>,
+                    <Button style={{borderRadius: 4, borderWidth: 0, marginRight: 8}} key="back"
+                            onClick={handleRequestRevision}>
+                        Ask for revision
                     </Button>,
                     <Button style={{borderRadius: 4}} key="submit" type="primary"
                             onClick={handleOk}>

--- a/graphql/mutations.ts
+++ b/graphql/mutations.ts
@@ -301,6 +301,15 @@ export const REJECT_TASK = gql`
   }
 `;
 
+export const REQUEST_REVISION_TASK = gql`
+  mutation requestRevisionTask($taskId: Int!) {
+    requestRevisionTask(taskId: $taskId) {
+      success
+      message
+    }
+  }
+`;
+
 export const APPROVE_TASK = gql`
   mutation approveTask($taskId: Int!) {
     approveTask(taskId: $taskId) {

--- a/pages/[personSlug]/[productSlug]/tasks/[publishedId].tsx
+++ b/pages/[personSlug]/[productSlug]/tasks/[publishedId].tsx
@@ -32,6 +32,7 @@ import {
     IN_REVIEW_TASK,
     LEAVE_TASK,
     REJECT_TASK,
+    REQUEST_REVISION_TASK,
     APPROVE_TASK,
 } from "../../../../graphql/mutations";
 import {getProp} from "../../../../utilities/filters";
@@ -228,6 +229,29 @@ const Task: React.FunctionComponent<Params> = ({
             },
             onError() {
                 message.error("Failed to reject a work!").then();
+            },
+        }
+    );
+
+    const [requestRevisionTask, {loading: requestRevisionTaskLoading}] = useMutation(
+        REQUEST_REVISION_TASK,
+        {
+            variables: {taskId},
+            onCompleted(data) {
+                const {requestRevisionTask} = data;
+                const responseMessage = requestRevisionTask.message;
+                if (requestRevisionTask.success) {
+                    message.success(responseMessage).then();
+                    fetchData().then();
+                    showRejectTaskModal(false);
+                    setDeliveryModal(false);
+                    getPersonData();
+                } else {
+                    message.error(responseMessage).then();
+                }
+            },
+            onError() {
+                message.error("Failed to request revision for a work!").then();
             },
         }
     );
@@ -917,10 +941,12 @@ const Task: React.FunctionComponent<Params> = ({
                                 <CustomModal
                                     modal={rejectTaskModal}
                                     closeModal={() => showRejectTaskModal(false)}
-                                    submit={rejectTask}
+                                    submit={requestRevisionTask}
                                     title="Reject the work"
-                                    message="Do you really want to reject the work?"
-                                    submitText="Yes, reject"
+                                    message="Please choose one of the options below to reject the contribution."
+                                    submitText="Ask for revision"
+                                    secondarySubmits={[{text:"Unassign", action: rejectTask}]}
+                                    displayCancelButton={false}
                                 />
                             )}
                             {approveTaskModal && (
@@ -937,8 +963,9 @@ const Task: React.FunctionComponent<Params> = ({
                                 <DeliveryMessageModal
                                     modal={deliveryModal}
                                     closeModal={() => setDeliveryModal(false)}
-                                    submit={approveTask}
                                     reject={rejectTask}
+                                    requestRevision={requestRevisionTask}
+                                    submit={approveTask}
                                     taskId={taskId}/>
                             )}
                         </>


### PR DESCRIPTION
Now there are two options to reject a task:

- Unassign: reject the task and make it available again so others can pick up
- Ask for revision: reject the contribution but the task is left in progress under the current person who claimed

![image](https://user-images.githubusercontent.com/99771440/160726081-1fc423b8-6394-443b-8bfd-86676fc09e05.png)
![image](https://user-images.githubusercontent.com/99771440/160726724-a738d9dc-359c-4576-b0e5-b39b7c30e905.png)
